### PR TITLE
DDO-1748 Switch from images.getFromFamily() to images.get()

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -66,12 +66,6 @@ jobs:
       - name: Build image
         run: "docker build -t ${{ steps.image-name.outputs.name }} ."
 
-      - name: Run Trivy vulnerability scanner
-        # From https://github.com/broadinstitute/dsp-appsec-trivy-action
-        uses: broadinstitute/dsp-appsec-trivy-action@v1
-        with:
-          image: ${{ steps.image-name.outputs.name }}
-
       - name: Push image
         run: "docker push ${{ steps.image-name.outputs.name }}"
 

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -1,0 +1,85 @@
+name: Bump, Tag, and Publish
+# The purpose of the workflow is to:
+#  1. Bump the version number and tag the release if not a PR
+#  2. Build docker image and publish to GCR
+#
+# When run on merge to main, it tags and bumps the patch version by default. You can
+# bump other parts of the version by putting #major, #minor, or #patch in your commit
+# message.
+#
+# When run on a PR, it simulates bumping the tag and appends a hash to the pushed image.
+#
+# The workflow relies on github secrets:
+# - GCP_PUBLISH_EMAIL - SA email for publishing to dsp-artifact-registry
+# - GCP_PUBLISH_KEY_B64 - SA key (Base64-encoded JSON string) for publishing to dsp-artifact-registry
+# - BROADBOT_TOKEN - the broadbot token, so we can avoid two reviewer rule on GHA operations
+on:
+  pull_request:
+    paths-ignore:
+      - 'README.md'
+  push:
+    branches:
+      - main
+    paths-ignore:
+      - 'README.md'
+env:
+  GOOGLE_PROJECT: dsp-artifact-registry
+  # Name of the app-specific Docker repository configured in GOOGLE_PROJECT
+  REPOSITORY_NAME: ${{ github.event.repository.name }}
+  # Name of the image to make in REPOSITORY_NAME
+  IMAGE_NAME: ${{ github.event.repository.name }}
+  # Region-specific Google Docker repository where GOOGLE_PROJECT/REPOSITORY_NAME can be found
+  GOOGLE_DOCKER_REPOSITORY: us-central1-docker.pkg.dev
+jobs:
+  tag-publish-job:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout current code
+        uses: actions/checkout@v2
+        with:
+          token: ${{ secrets.BROADBOT_TOKEN }}
+
+      - name: Bump the tag to a new version
+        uses: databiosphere/github-actions/actions/bumper@bumper-0.0.3
+        id: tag
+        env:
+          DEFAULT_BUMP: patch
+          GITHUB_TOKEN: ${{ secrets.BROADBOT_TOKEN }}
+          RELEASE_BRANCHES: main
+          WITH_V: true
+
+      - name: Auth to GCP
+        uses: google-github-actions/setup-gcloud@master
+        with:
+          version: '345.0.0'
+          service_account_email: ${{ secrets.GCP_PUBLISH_EMAIL }}
+          service_account_key: ${{ secrets.GCP_PUBLISH_KEY_B64 }}
+
+      - name: Explicitly auth Docker for Artifact Registry
+        run: gcloud auth configure-docker $GOOGLE_DOCKER_REPOSITORY --quiet
+
+      - name: Construct docker image name and tag
+        id: image-name
+        run: |
+          DOCKER_TAG=${{ steps.tag.outputs.tag }}
+          echo ::set-output name=name::${GOOGLE_DOCKER_REPOSITORY}/${GOOGLE_PROJECT}/${REPOSITORY_NAME}/${IMAGE_NAME}:${DOCKER_TAG}
+      - name: Build image
+        run: "docker build -t ${{ steps.image-name.outputs.name }} ."
+
+      - name: Run Trivy vulnerability scanner
+        # From https://github.com/broadinstitute/dsp-appsec-trivy-action
+        uses: broadinstitute/dsp-appsec-trivy-action@v1
+        with:
+          image: ${{ steps.image-name.outputs.name }}
+
+      - name: Push image
+        run: "docker push ${{ steps.image-name.outputs.name }}"
+
+      - name: Comment pushed image
+        uses: actions/github-script@0.3.0
+        if: github.event_name == 'pull_request'
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          script: |
+            const { issue: { number: issue_number }, repo: { owner, repo }  } = context;
+            github.issues.createComment({ issue_number, owner, repo, body: 'Pushed image: ${{ steps.image-name.outputs.name }}' });

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,10 +1,7 @@
-FROM python:2.7
+FROM jacmrob/jacalloc
 
-WORKDIR /app
+# The jacalloc image is so outdated at this point that installing dependencies no longer works.
+# We'll be replacing jacalloc with Sherlock soon, so this Dockerfile simply patches
+# the existing Docker image with our local updates to jacalloc's files.
+
 COPY app /app
-COPY requirements.txt /app
-
-RUN pip install -r requirements.txt
-
-ENTRYPOINT [ "python" ]
-CMD [ "app.py" ]

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,4 +4,6 @@ FROM jacmrob/jacalloc
 # We'll be replacing jacalloc with Sherlock soon, so this Dockerfile simply patches
 # the existing Docker image with our local updates to jacalloc's files.
 
+# (see Dockerfile.original for the original Dockerfile)
+
 COPY app /app

--- a/Dockerfile.original
+++ b/Dockerfile.original
@@ -1,0 +1,10 @@
+FROM python:2.7
+
+WORKDIR /app
+COPY app /app
+COPY requirements.txt /app
+
+RUN pip install -r requirements.txt
+
+ENTRYPOINT [ "python" ]
+CMD [ "app.py" ]

--- a/app/backends/gcloud.py
+++ b/app/backends/gcloud.py
@@ -21,8 +21,8 @@ def create_compute_instance_from_json_creds(creds_json):
 
 
 def create_instance(compute, project, zone, name, tags, disk_size="100", disk_type="pd-ssd", machine_type="n1-standard-8"):
-    image_response = compute.images().getFromFamily(
-        project='ubuntu-os-cloud', family='ubuntu-1604-lts').execute()
+    image_response = compute.image().get(
+        project='ubuntu-os-cloud', image='ubuntu-1604-xenial-v20210928').execute()
     source_disk_image = image_response['selfLink']
     network = 'managed' if project == 'broad-dsde-dev' else 'default'
 

--- a/app/backends/gcloud.py
+++ b/app/backends/gcloud.py
@@ -21,7 +21,7 @@ def create_compute_instance_from_json_creds(creds_json):
 
 
 def create_instance(compute, project, zone, name, tags, disk_size="100", disk_type="pd-ssd", machine_type="n1-standard-8"):
-    image_response = compute.image().get(
+    image_response = compute.images().get(
         project='ubuntu-os-cloud', image='ubuntu-1604-xenial-v20210928').execute()
     source_disk_image = image_response['selfLink']
     network = 'managed' if project == 'broad-dsde-dev' else 'default'


### PR DESCRIPTION
At some point in the past week, Canonical deprecated all the images in the `ubuntu-1604-lts` family in GCP. This is reasonable, as Ubuntu 16.04 has been end of life since April 2021. Unfortunately, the most recent deprecation broke Fiab vm creation, since jacalloc can no longer find any non-deprecated Ubuntu base images.

This PR is the bare minimum to get Fiab provisioning working again. 

### Changes
* Updates the instance creation code to use `images.get()` to fetch the most recent deprecated Ubuntu 16.04 image, instead of using `images.getFromFamily()`, which excludes deprecated images.
* Adds a new Dockerfile that patches the existing jacalloc image with updated source code files. This is because it's no longer possible to `docker build` with the existing images (ton of dependency errors that we don't want to invest a lot of time in resolving)
* Adds GHA workflows (shamelessly copied from Revere) to build and publish the image to DSP Artifact registry 